### PR TITLE
[ BE ][ 서비스 > 결제완료 ]

### DIFF
--- a/backend/service/order_service.py
+++ b/backend/service/order_service.py
@@ -196,34 +196,50 @@ class OrderService:
 
         """
 
+        # orders_details테이블과 user_shipping_details테이블에 필요한 user_no의 정보를 order_info에 넣어줍니다.
+        order_info['user_no'] = user_no
+        print(1)
+
+        # 해당 유저의 배송지 정보가 없었으면, 새로 받아온 후, 그 배송지 정보를 넣어주고,
+        # 만약 유저의 배송지 정보가 있었는데, 새로운 정보가 들어왔다면 그 정보로 UPDATE를 해줍니다.
+        self.order_dao.update_user_shipping_details_info(order_info, db_connection)
+        print(2)
+
         # 유저의 id를 넘겨주고, orders 테이블에 insert후, 해당 order_no의 id(pk)를 가져옵니다.
         order_info['order_no'] = self.order_dao.insert_orders(user_no, db_connection)
-
-        # orders_details테이블에 필요한 user_no의 정보를 order_info에 넣어줍니다.
-        order_info['user_no'] = user_no
+        print(3)
+        print(order_info)
 
         # orders_details에 생성된 테이블의 id(pk)를 order_info에 넣어줍니다.
         order_info['order_detail_no']  = self.order_dao.insert_orders_details(order_info, db_connection)
+        print(4)
+
+        # 서브쿼리를 줄이기 위해, product_option_no을 가져와 order_info에 넣어줍니다.
+        product_option_no = self.order_dao.get_product_option_no(order_info, db_connection)
+        order_info = {**order_info, **product_option_no}
 
         # order_product 테이블 row 생성
         order_info['order_product_no'] = self.order_dao.insert_order_product(order_info, db_connection)
-
-        # 서브 쿼리를 최소화 하기 위해 option_details 테이블의 pk를 넣어줍니다.
-        order_info = {**order_info, **self.order_dao.get_option_details(order_info, db_connection)}
+        print(6)
 
         # 현재 제품의 재고 pk 가져오는 메소드 실행
         current_quantity_info = self.order_dao.get_current_quantity(order_info, db_connection)
+        print(7)
 
         # 새로운 재고 생성하는 메소드 실행
         new_quantity_no = self.order_dao.insert_quantities(order_info, db_connection)
+        print(8)
 
         # start_time 가져오는 메소드 실행
-        start_time = self.order_dao.get_order_detail_start_time(new_quantity_no, db_connection)
+        start_time = self.order_dao.get_quantity_start_time(new_quantity_no, db_connection)
+        print(9)
 
         # 원래 재고 pk에 close_time 설정
         current_quantity_info['close_time'] = start_time
+        print(10)
 
         # 원래 재고 row의 close_time 설정하는 메소드 실행
         updated_quantity = self.order_dao.update_quantities(current_quantity_info, db_connection)
+        print(11)
 
-        return new_quantity
+        return 1


### PR DESCRIPTION
- Quantity(수량)에 대한 선분이력 구현 완료.

- 테이블 병합으로 인해 주문 관련 일부 쿼리문 수정.

- 헤더에 담긴 해당 유저의 배송지 정보를 리턴, 만약 유저의 배송지가 없다면 null로 리턴.

- 사용자가 배송지 정보에 새로운 배송지 정보를 줄 경우,
원래 사용자의 배송지 정보가 없었으면 user_shipping_details에 insert.
원래 사용자의 배송지 정보가 있었으면 user_shipping_details에 update.

[ 서비스 > 구매할 상품정보 ]
- 테이블 병합으로 인해 프론트에게 주던 product_option_id 키 값 제거.