### PR TITLE
[ BE ][ 서비스 > 결제완료 ]

### DIFF
--- a/backend/model/order_dao.py
+++ b/backend/model/order_dao.py
@@ -578,14 +578,14 @@ class OrderDao:
         except Exception as e:
             raise e
 
-    def insert_orders(self, user_no, db_connection):
+    def insert_orders(self, order_info, db_connection):
 
         """
 
         user의 id를 받아와 orders라는 주문 테이블의 행을 추가합니다.
 
         Args:
-            user_no       : 토큰에서 부터 받아온 해당 유저의 id
+            order_info    : 주문 정보, 유저 id에 관한 정보도 있음.
             db_connection : 연결된 db 객체
 
         Returns:
@@ -609,11 +609,11 @@ class OrderDao:
                 INSERT INTO orders (
                     user_id
                 ) VALUES (
-                    %s
+                    %(user_no)s
                 );
                 """
 
-                new_orders_row = cursor.execute(insert_orders_query, user_no)
+                new_orders_row = cursor.execute(insert_orders_query, order_info)
 
                 if new_orders_row <= 0:
                     raise Exception('QUERY_FAILED')
@@ -739,14 +739,14 @@ class OrderDao:
         except Exception as e:
             raise e
 
-    def update_quantities(self, data, db_connection):
+    def update_quantities(self, update_quantity_info, db_connection):
 
         """
 
         원래 quantity row의 close_time을 업데이트 합니다..
 
         Args:
-            data:
+            current_quantity_info:
                 quantity_no : 변경하려는 quantity_pk
                 start_time : 새로운 이력의 start_time
             db_connection : 연결된 db 객체
@@ -770,19 +770,17 @@ class OrderDao:
                 UPDATE
                     quantities
                 SET
-                    close_time = %(close_time)s
+                    close_time = %(start_time)s
                 WHERE
-                    quantity_no = %(quantity_no)s
+                    quantity_no = %(origin_quantity_no)s
                 """
 
-                # 한 유저당 하나의 배송지 정보를 저장할 수 있으므로 하나만 가져옵니다.
-                affected_row = cursor.execute(update_quantities_query, data)
+                affected_row = cursor.execute(update_quantities_query, update_quantity_info)
 
                 if affected_row < 0:
                     raise Exception("Query Failed")
 
-                # orders_details의 생성된 테이블의 pk를 반환해줍니다.
-                return cursor.lastrowid
+                return 1
 
         except KeyError as e:
             raise e
@@ -808,6 +806,10 @@ class OrderDao:
 
         History:
             2020-09-07 (minho.lee0716@gmail.com) : 초기 생성
+            2020-09-09 (minho.lee0716@gmail.com) : 수정
+                테이블 변경으로 인해, 새로운 선분을 추가하는 테이블에 수량은
+                product_options  테이블의 수량을 가져오는 것으로 변경하였습니다.
+                (현재 product_options 테이블에는, 원래의 재고에서 유저가 구매한 만큼의 재고가 빠져있기 때문입니다.)
 
         """
 
@@ -815,33 +817,33 @@ class OrderDao:
 
             with db_connection.cursor() as cursor:
 
-                # U라는 테이블이 '주문자 정보'에 관한 정보입니다.
+                # 새로운 선분이력을 생성하는 quantities테이블의 row를 생성하는 쿼리입니다.
                 insert_quantities_query = """
                 INSERT INTO quantities (
                     product_option_id,
                     quantity
                 ) VALUES (
-                %(product_option_no)s,
-                (
+                    %(product_option_no)s,
+                    (
                     SELECT
-                        Q.quantity
+                        current_quantity
 
-                    FROM quantities AS Q
+                    FROM
+                        product_options
 
                     WHERE
-                        Q.close_time = '9999-12-31 23:59:59'
-                        AND Q.product_option_id =  %(product_option_no)s
-                ) - %(quantity)s
+                    product_option_no = %(product_option_no)s
+                    )
                 )
                 """
 
-                # 한 유저당 하나의 배송지 정보를 저장할 수 있으므로 하나만 가져옵니다.
-                new_quantities_row = cursor.execute(insert_quantities_query, order_info)
+                # quantities테이블에 row를 생성하는 쿼리와 quantity관련 정보를 인자로 주어 row를 생성합니다.
+                affected_row = cursor.execute(insert_quantities_query, order_info)
 
-                if new_quantities_row <= 0:
+                if affected_row <= 0:
                     raise Exception('QUERY_FAILED')
 
-                # orders_details의 생성된 테이블의 pk를 반환해줍니다.
+                # 생성된 quantities테이블의 row id를 리턴해 줍니다.
                 return cursor.lastrowid
 
         except KeyError as e:
@@ -850,24 +852,27 @@ class OrderDao:
         except Exception as e:
             raise e
 
-    def get_current_quantity(self, order_info, db_connection):
+    def get_current_quantity(self, product_option_no, db_connection):
 
         """
 
-        user의 id를 받아와 orders라는 주문 테이블의 컬럼을 추가합니다.
+        해당 옵션에 해당하는 product_option테이블의 id를 가져와 그 옵션의 현재 재고를 리턴해주는 메소드입니다.
 
         Args:
-            user_no       : 토큰에서 부터 받아온 해당 유저의 id
-            db_connection : 연결된 db 객체
+            product_option_no : 구매하려는 옵션의 id
+            db_connection     : 연결된 db 객체
 
         Returns:
-            order_no : insert한 해당 orders라는 테이블의 id(pk)
+            {"current_quantity" : 해당 옵션의 현재 재고 }
 
         Authors:
             minho.lee0716@gmail.com (이민호)
 
         History:
             2020-09-07 (minho.lee0716@gmail.com) : 초기 생성
+            2020-09-09 (minho.lee0716@gmail.com) : 수정
+                테이블 변경으로 인해 Quantities테이블에서 가져오던 현재 재고를
+                Product_options라는 테이블에서 가져오는걸로 변경하였습니다.
 
         """
 
@@ -875,23 +880,23 @@ class OrderDao:
 
             with db_connection.cursor() as cursor:
 
-                # U라는 테이블이 '주문자 정보'에 관한 정보입니다.
+                # 현재 상품의 재고를 가져오는 쿼리문 입니다.
                 select_quantities_query = """
                 SELECT
-                    Q.quantity_no
+                    PO.current_quantity
 
                 FROM
-                quantities AS Q
+                product_options AS PO
 
                 WHERE
-                Q.product_option_id = %(product_option_no)s
-                AND Q.close_time = '9999-12-31 23:59:59'
+                PO.product_option_no = %(product_option_no)s
+                AND PO.is_deleted = False
                 """
 
-                # 한 유저당 하나의 배송지 정보를 저장할 수 있으므로 하나만 가져옵니다.
-                cursor.execute(select_quantities_query, order_info)
+                # 어떤 옵션의 재고인지 product_option_no을 인자로 받아와,
+                cursor.execute(select_quantities_query, product_option_no)
 
-                # orders_details의 생성된 테이블의 pk를 반환해줍니다.
+                # 해당 옵션의 재고를 반환해 줍니다.
                 return cursor.fetchone()
 
         except KeyError as e:
@@ -942,10 +947,10 @@ class OrderDao:
                 AND product_id = %(product_id)s
                 """
 
+                # 쿼리문과 필요한 정보를 인자로 넘겨주어 메소드를 실행하고,
                 cursor.execute(select_product_option_no_query, order_info)
 
-                # orders_details의 생성된 테이블의 pk를 반환해줍니다.(타입은 딕셔너리 입니다.)
-                # 한 유저당 하나의 배송지 정보를 저장할 수 있으므로 하나만 가져옵니다.
+                # 해당 옵션의 id 값을 리턴해 줍니다.
                 return cursor.fetchone()
 
         except KeyError as e:
@@ -992,7 +997,7 @@ class OrderDao:
 
             return start_time['start_time'].strftime('%Y-%m-%d %H:%M:%S')
 
-    def update_user_shipping_details_info(self, order_info, db_connection):
+    def select_user_shipping_details_info(self, order_info, db_connection):
 
         """
 
@@ -1004,12 +1009,13 @@ class OrderDao:
 
         Returns:
 
-
         Authors:
             minho.lee0716@gmail.com (이민호)
 
         History:
             2020-09-08 (minho.lee0716@gmail.com) : 초기 생성
+            2020-09-09 (minho.lee0716@gmail.com) : 수정
+                select, insert, update 쿼리문 분리
 
         """
 
@@ -1033,6 +1039,42 @@ class OrderDao:
                 USD.user_id = %(user_no)s
                 """
 
+                cursor.execute(select_user_shipping_details_query, order_info)
+
+                return cursor.fetchone()
+
+        except KeyError as e:
+            raise e
+
+        except Exception as e:
+            raise e
+
+    def insert_user_shipping_details_info(self, order_info, db_connection):
+
+        """
+
+        order_info의 객체에서 배송지 정보를 받아와 해당 유저의 새로운 배송지 정보를 생성해주는 메소드입니다.
+
+        Args:
+            order_info    : 해당 유저가 입력한 배송지 정보.
+            db_connection : 연결된 db 객체
+
+        Returns:
+
+        Authors:
+            minho.lee0716@gmail.com (이민호)
+
+        History:
+            2020-09-08 (minho.lee0716@gmail.com) : 초기 생성
+            2020-09-09 (minho.lee0716@gmail.com) : 수정
+                select, insert, update 쿼리문 분리
+
+        """
+
+        try:
+
+            with db_connection.cursor() as cursor:
+
                 # 유저의 id를 확인후, 해당 유저의 배송지 정보를 추가하는 쿼리문 입니다
                 insert_user_shipping_details_query = """
                 INSERT INTO user_shipping_details (
@@ -1052,6 +1094,45 @@ class OrderDao:
                 )
                 """
 
+                user_shipping_details_info = cursor.execute(insert_user_shipping_details_query, order_info)
+
+                if user_shipping_details_info <= 0:
+                    raise Exception('QUERY_FAILED')
+
+                return 1
+
+        except KeyError as e:
+            raise e
+
+        except Exception as e:
+            raise e
+
+    def update_user_shipping_details_info(self, order_info, db_connection):
+
+        """
+
+        order_info의 객체에서 배송지 정보를 받아와 해당 유저의 새로운 배송지 정보로 업데이트 해주는 메소드입니다.
+
+        Args:
+            order_info    : 해당 유저가 입력한 배송지 정보.
+            db_connection : 연결된 db 객체
+
+        Returns:
+
+        Authors:
+            minho.lee0716@gmail.com (이민호)
+
+        History:
+            2020-09-08 (minho.lee0716@gmail.com) : 초기 생성
+            2020-09-09 (minho.lee0716@gmail.com) : 수정
+                select, insert, update 쿼리문 분리
+
+        """
+
+        try:
+
+            with db_connection.cursor() as cursor:
+
                 # 유저의 id를 확인후, 해당 유저의 배송지 정보를 업데이트하는 쿼리문 입니다.
                 update_user_shipping_details_query = """
                 UPDATE
@@ -1068,21 +1149,110 @@ class OrderDao:
                 user_id = %(user_no)s
                 """
 
-                user_shipping_info = cursor.execute(select_user_shipping_details_query, order_info)
-
-                # 사용자의 배송지 정보가 존재한다면,
-                if user_shipping_info:
-
-                    # 들어온 배송지의 정보로 Update를 해줍니다.
-                    cursor.execute(update_user_shipping_details_query, order_info)
-
-                # 사용자의 배송지 정보가 존재하지 않는다면,,
-                else:
-
-                    # 사용자의 배송지 정보가 존재하지 않았다면, 들어온 배송지의 정보를 Insert 해줍니다.
-                    cursor.execute(insert_user_shipping_details_query, order_info)
+                cursor.execute(update_user_shipping_details_query, order_info)
 
                 return 1
+
+        except KeyError as e:
+            raise e
+
+        except Exception as e:
+            raise e
+
+    def update_current_quantity(self, order_info, db_connection):
+
+        """
+
+        product_options 테이블에있는 재고에서 받아온 주문 정보에 대한 수량을 빼주는 메소드입니다.
+
+        Args:
+            order_info    : 주문 정보
+            db_connection : 연결된 db 객체
+
+        Returns:
+
+        Authors:
+            minho.lee0716@gmail.com (이민호)
+
+        History:
+            2020-09-09 (minho.lee0716@gmail.com) : 초기 생성
+
+        """
+
+        try:
+
+            with db_connection.cursor() as cursor:
+
+                # 현재 재고에서 받아온 수량을 빼주는 update 쿼리입니다.
+                update_current_quantities_query = """
+                UPDATE
+                    product_options
+                SET
+                current_quantity = current_quantity - %(quantity)s
+
+                WHERE
+                product_option_no = %(product_option_no)s
+                """
+
+                # update쿼리문과 주문 정보를 인자로 주어 현재 재고를 업데이트 해줍니다.
+                affected_row = cursor.execute(update_current_quantities_query, order_info)
+
+                # 변경된 사항이 없다면 에러를 보내줍니다.
+                if affected_row < 0:
+                    raise Exception("Query Failed")
+
+                return 1
+
+        except KeyError as e:
+            raise e
+
+        except Exception as e:
+            raise e
+
+    def get_origin_quantity_no(self, order_info, db_connection):
+
+        """
+
+        quantities테이블의 원래 선분이력의 row id를 가져오는 메소드
+
+        Args:
+            order_info    : 주문 정보
+            db_connection : 연결된 db 객체
+
+        Returns:
+
+        Authors:
+            minho.lee0716@gmail.com (이민호)
+
+        History:
+            2020-09-09 (minho.lee0716@gmail.com) : 초기 생성
+
+        """
+
+        try:
+
+            with db_connection.cursor() as cursor:
+
+                # 현재 재고에서 받아온 수량을 빼주는 update 쿼리입니다.
+                get_origin_quantity_query = """
+                SELECT
+                quantity_no
+
+                FROM quantities
+
+                WHERE
+                product_option_id = %(product_option_no)s
+                AND close_time = '9999-12-31 23:59:59'
+                """
+
+                # update쿼리문과 주문 정보를 인자로 주어 현재 재고를 업데이트 해줍니다.
+                affected_row = cursor.execute(get_origin_quantity_query, order_info)
+
+                # 변경된 사항이 없다면 에러를 보내줍니다.
+                if affected_row < 0:
+                    raise Exception("Query Failed")
+
+                return cursor.fetchone()
 
         except KeyError as e:
             raise e

--- a/backend/model/product_dao.py
+++ b/backend/model/product_dao.py
@@ -846,6 +846,8 @@ class ProductDao:
                 DB에서 데이터의 순서에 의해, 마지막에 역순으로 정렬
             2020-09-04 (tnwjd060124@gmail.com) : 수정
                 현재 이력만 조회하는 조건 수정
+            2020-09-01 (minho.lee0716@gmail.com) : 수정
+                상품과 사이즈를 선택 시, 수량이 1개 이상인 상품만 주도록 쿼리문 변경
 
         """
 
@@ -877,6 +879,7 @@ class ProductDao:
                 P.product_no = %(product_id)s
                 AND P.is_deleted = False
                 AND C.color_no = %(color_id)s
+                AND Q.quantity > 0
 
             ORDER BY
                 S.size_no DESC;

--- a/backend/schema/brandi_schema_v2.3.sql
+++ b/backend/schema/brandi_schema_v2.3.sql
@@ -1,0 +1,2327 @@
+drop database brandi;
+
+create database brandi character set utf8mb4 collate utf8mb4_general_ci;
+use brandi;
+
+SET time_zone='Asia/Seoul';
+
+-- products Table Create SQL
+CREATE TABLE products
+(
+    `product_no`  INT         NOT NULL    AUTO_INCREMENT COMMENT 'pk', 
+    `created_at`  DATETIME    NOT NULL    DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시', 
+    `is_deleted`  TINYINT     NOT NULL    DEFAULT FALSE COMMENT '삭제여부', 
+    `product_code`  VARCHAR(50)    NOT NULL    COMMENT '상품 코드',
+    PRIMARY KEY (product_no)
+);
+
+INSERT INTO products
+(
+    product_no,
+    product_code
+) VALUES (
+    1,
+   '447acee5-1a6f-45d3-a630-fa9db6cec51a' 
+), (
+    2,
+    'cd998fc3-43cc-4f3b-9a70-b2ad67fde612'
+), (
+    3,
+    '34059e97-775d-4176-8b9c-467687e28fa6'
+), (
+    4,
+    'cd5c18b2-ffba-4b70-98a5-1ff76c9b4cf8'
+), (
+    5,
+    'd2be6842-23c4-48af-b667-32046585b292'
+), (
+    6,
+    '63caf721-0bcb-415d-80b5-7fc6852f9e5e'
+), (
+    7,
+    '7ac1f9c4-e34e-4013-a8ff-fd7e8d34cb8a'
+), (
+    8,
+    '8d0e3b90-2a27-40af-8a2a-92e14b05402d'
+), (
+    9,
+    '0839b2c9-e741-41d6-bed8-eb10c034478d'
+), (
+    10,
+    'edbdbe99-2011-4d4b-ac1d-6b24b25b01b6'
+), (
+    11,
+    '5ae73934-d0e4-4cff-8785-d973f7ec0553'
+), (
+    12,
+    'd75475e3-4a30-43b6-96b2-a9e71e23044c'
+), (
+    13,
+    'd5549f63-48fd-4c0c-b70d-521a677d7bae'
+), (
+    14,
+    '715fbe44-7109-48c1-83c6-7f55789a44ea'
+), (
+    15,
+    '0a8ed894-7489-4bfb-9b28-88aa8a760e80'
+), (
+    16,
+    '7b12a5a3-99c2-4f36-b8dc-c2ceb764cd4e'
+), (
+    17,
+    '0d5ed9ae-bd8d-4974-907c-927d1858fd2e'
+), (
+    18,
+    'cc0bc286-f632-438a-8117-f6e106c61ca3'
+), (
+    19,
+    'aa616244-ec2c-4d0e-8d37-595b238df355'
+), (
+    20,
+    '5ca04d97-8178-40ea-8cc8-d3f20a5640d4'
+);
+
+-- colors Table Create SQL
+CREATE TABLE colors
+(
+    `color_no`  INT             NOT NULL    AUTO_INCREMENT COMMENT 'pk', 
+    `name`      VARCHAR(50)    NOT NULL    COMMENT '색상명', 
+    PRIMARY KEY (color_no)
+);
+
+ALTER TABLE colors COMMENT '색상 옵션';
+
+INSERT INTO colors
+(
+    color_no,
+    name
+) VALUES (
+    1,
+    '블랙'
+), (
+    2,
+    '화이트'
+), (
+    3,
+    '그레이'
+), (
+    4,
+    '아이보리'
+), (
+    5,
+    '네이비'
+), (
+    6,
+    '블루'
+), (
+    7,
+    '레드'
+), (
+    8,
+    '핑크'
+), (
+    9,
+    '옐로우'
+), (
+    10,
+    '베이지'
+), (
+    11,
+    '연청'
+), (
+    12,
+    '민트'
+), (
+    13,
+    '진청'
+), (
+    14,
+    '연베이지'
+), (
+    15,
+    '중청'
+), (
+    16,
+    '소라'
+), (
+    17,
+    '그린'
+), (
+    18,
+    '연퍼플'
+), (
+    19,
+    '머스터드'
+), (
+    20,
+    '퍼플'
+), (
+    21,
+    '청록'
+), (
+    22,
+    '딥핑크'
+), (
+    23,
+    '인디핑크'
+), (
+    24,
+    '딥그린'
+), (
+    25,
+    '카키'
+), (
+    26,
+    '와인'
+), (
+    27,
+    '브라운'
+), (
+    28,
+    '실버'
+), (
+    29,
+    '크림'
+), (
+    30,
+    '차콜'
+), (
+    31,
+    '오렌지'
+), (
+    32,
+    '올리브'
+), (
+    33,
+    '라이트베이지'
+), (
+    34,
+    '다크베이지'
+), (
+    35,
+    '골드'
+), (
+    36,
+    '라임'
+), (
+    37,
+    '라이트블루'
+), (
+    38,
+    '피치핑크'
+), (
+    39,
+    '오트밀'
+);
+
+
+-- sizes Table Create SQL
+CREATE TABLE sizes
+(
+    `size_no`  INT            NOT NULL    AUTO_INCREMENT COMMENT 'pk', 
+    `name`     VARCHAR(50)    NOT NULL    COMMENT '사이즈명', 
+    PRIMARY KEY (size_no)
+);
+
+ALTER TABLE sizes COMMENT '사이즈 옵션';
+
+INSERT INTO sizes
+(
+    size_no,
+    name
+) VALUES (
+    1,
+    'Free'
+), (
+    2,
+    'XL'
+), (
+    3,
+    'L'
+), (
+    4,
+    'M'
+), (
+    5,
+    'S'
+), (
+    6,
+    'XS'
+), (
+    7,
+    25
+), (
+    8,
+    26
+), (
+    9,
+    27
+), (
+    10,
+    28
+), (
+    11,
+    29
+), (
+    12,
+    30
+), (
+    13,
+    32
+), (
+    14,
+    34
+), (
+    15,
+    35
+), (
+    16,
+    36
+), (
+    17,
+    37
+), (
+    18,
+    38
+), (
+    19,
+    39
+), (
+    20,
+    40
+), (
+    21,
+    85
+), (
+    22,
+    90
+), (
+    23,
+    95
+), (
+    24,
+    100
+), (
+    25,
+    105
+), (
+    26,
+    'XXL'
+), (
+    27,
+    'XXXL'
+), (
+    28,
+    'XXXXL'
+), (
+    29,
+    'M(44-55)'
+), (
+    30,
+    'L(55-66)'
+), (
+    31,
+    'L(55-마른66)'
+), (
+    32,
+    210
+), (
+    33,
+    215
+), (
+    34,
+    220
+), (
+    35,
+    225
+), (
+    36,
+    230
+), (
+    37,
+    235
+), (
+    38,
+    240
+), (
+    39,
+    245
+), (
+    40,
+    250
+), (
+    41,
+    255
+), (
+    42,
+    260
+), (
+    43,
+    265
+), (
+    44,
+    270
+), (
+    45,
+    275
+), (
+    46,
+    280
+), (
+    47,
+    285
+), (
+    48,
+    290
+), (
+    49,
+    '1호'
+), (
+    50,
+    '2호'
+), (
+    51,
+    '3호'
+), (
+    52,
+    '4호'
+), (
+    53,
+    '5호'
+), (
+    54,
+    '6호'
+), (
+    55,
+    '7호'
+), (
+    56,
+    '8호'
+), (
+    57,
+    '9호'
+), (
+    58,
+    '10호'
+), (
+    59,
+    '11호'
+), (
+    60,
+    '12호'
+), (
+    61,
+    '13호'
+), (
+    62,
+    '14호'
+), (
+    63,
+    '15호'
+), (
+    64,
+    '16호'
+), (
+    65,
+    '17호'
+), (
+    66,
+    '18호'
+), (
+    67,
+    '19호'
+), (
+    68,
+    '70a'
+), (
+    69,
+    '70b'
+), (
+    70,
+    '70c'
+), (
+    71,
+    '70d'
+), (
+    72,
+    '70e'
+), (
+    73,
+    '70f'
+), (
+    74,
+    '70g'
+), (
+    75,
+    '75a'
+), (
+    76,
+    '75b'
+), (
+    77,
+    '75c'
+), (
+    78,
+    '75d'
+), (
+    79,
+    '75e'
+), (
+    80,
+    '75f'
+), (
+    81,
+    '75g'
+), (
+    82,
+    '80a'
+), (
+    83,
+    '80b'
+), (
+    84,
+    '80c'
+), (
+    85,
+    '80d'
+), (
+    86,
+    '80e'
+), (
+    87,
+    '80f'
+), (
+    88,
+    '80g'
+), (
+    89,
+    '85a'
+), (
+    90,
+    '85b'
+), (
+    91,
+    '85c'
+), (
+    92,
+    '85d'
+), (
+    93,
+    '85e'
+), (
+    94,
+    '85f'
+), (
+    95,
+    '85g'
+), (
+    96,
+    '90a'
+), (
+    97,
+    '90b'
+), (
+    98,
+    '90c'
+), (
+    99,
+    '90d'
+), (
+    100,
+    '90e'
+), (
+    101,
+    '90f'
+), (
+    102,
+    '90g'
+), (
+    103,
+    '95a'
+), (
+    104,
+    '95b'
+), (
+    105,
+    '95c'
+), (
+    106,
+    '95d'
+), (
+    107,
+    '95e'
+), (
+    108,
+    '95f'
+), (
+    109,
+    '95g'
+), (
+    110,
+    '100a'
+), (
+    111,
+    '100b'
+), (
+    112,
+    '100c'
+), (
+    113,
+    '100d'
+), (
+    114,
+    '100e'
+), (
+    115,
+    '100f'
+), (
+    116,
+    '100g'
+), (
+    117,
+    '105a'
+), (
+    118,
+    '105b'
+), (
+    119,
+    '105c'
+), (
+    120,
+    '105d'
+), (
+    121,
+    '105e'
+), (
+    122,
+    '105f'
+), (
+    123,
+    '105g'
+), (
+    124,
+    '아이폰8'
+), (
+    125,
+    '아이폰8플러스'
+), (
+    126,
+    '아이폰X'
+), (
+    127,
+    '갤럭시S9'
+), (
+    128,
+    '갤럭시S9플러스'
+);
+
+-- social_networks Table Create SQL
+CREATE TABLE social_networks
+(
+    `social_network_no`  INT            NOT NULL    AUTO_INCREMENT COMMENT 'pk', 
+    `name`               VARCHAR(45)    NOT NULL    COMMENT '소셜 이름', 
+    PRIMARY KEY (social_network_no)
+);
+
+INSERT INTO social_networks
+(
+    social_network_no,
+    name
+) VALUES (
+    1,
+    '구글'
+);
+
+-- users Table Create SQL
+CREATE TABLE users
+(
+    `user_no`         INT             NOT NULL    AUTO_INCREMENT COMMENT 'pk', 
+    `name`            VARCHAR(50)     NOT NULL    COMMENT '회원명', 
+    `email`           VARCHAR(255)    NOT NULL    UNIQUE COMMENT '이메일',
+    `password`        VARCHAR(50)     NULL        COMMENT '비밀번호', 
+    `created_at`      DATETIME        NOT NULL    DEFAULT CURRENT_TIMESTAMP COMMENT '등록일', 
+    `last_access`     DATETIME        NOT NULL    DEFAULT CURRENT_TIMESTAMP COMMENT '최종접속일', 
+    `social_id`       INT             NULL        COMMENT '소셜 종류_id', 
+    `user_social_id`  VARCHAR(50)     NULL        COMMENT '유저_소셜_id', 
+    `is_deleted`      TINYINT         NOT NULL    DEFAULT FALSE COMMENT '삭제여부', 
+    PRIMARY KEY (user_no)
+);
+
+ALTER TABLE users
+    ADD CONSTRAINT FK_social_id FOREIGN KEY (social_id)
+        REFERENCES social_networks (social_network_no) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+INSERT INTO users
+(
+    user_no,
+    name,
+    email,
+    password
+) VALUES (
+    1,
+    '손수정',
+    'soojung@soojung.com',
+    123456
+), (
+    2,
+    '이곤호',
+    'gonho@gonho.com',
+    123456
+), (
+    3,
+    '이민호',
+    'minho@minho.com',
+    123456
+), (
+    4,
+    '김경배',
+    'rudqo@rudqo.com',
+    123456
+), (
+    5,
+    '배정규',
+    'junggyoo@junggyoo.com',
+    123456
+);
+
+-- main_categories Table Create SQL
+CREATE TABLE main_categories
+(
+    `main_category_no`  INT            NOT NULL    AUTO_INCREMENT COMMENT 'pk', 
+    `name`              VARCHAR(50)    NOT NULL    COMMENT '카테고리명', 
+    PRIMARY KEY (main_category_no)
+);
+
+ALTER TABLE main_categories COMMENT '1차 카테고리';
+
+INSERT INTO main_categories
+(
+    main_category_no,
+    name
+) VALUES (
+    1,
+    '아우터'
+), (
+    2,
+    '상의'
+), (
+    3,
+    '바지'
+), (
+    4,
+    '원피스'
+), (
+    5,
+    '스커트'
+), (
+    6,
+    '신발'
+), (
+    7,
+    '가방'
+), (
+    8,
+    '주얼리'
+), (
+    9,
+    '잡화'
+), (
+    10,
+    '라이프웨어'
+), (
+    11,
+    '빅사이즈'
+);
+
+-- option_details Table Create SQL
+CREATE TABLE product_options
+(
+    `product_option_no`  INT         NOT NULL    AUTO_INCREMENT COMMENT 'pk', 
+    `product_id`         INT         NOT NULL    COMMENT '상품_id', 
+    `color_id`           INT         NOT NULL    COMMENT '색상_id', 
+    `size_id`            INT         NOT NULL    COMMENT '사이즈_id', 
+    `current_quantity`           INT         NOT NULL    COMMENT '재고',
+    `created_at`         DATETIME    NOT NULL    DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시', 
+    `deleted_at`         DATETIME    NULL        COMMENT '삭제일시',
+    `is_deleted`         TINYINT     NOT NULL    DEFAULT FALSE COMMENT '삭제여부', 
+    PRIMARY KEY (product_option_no)
+);
+
+ALTER TABLE product_options COMMENT '상품_옵션';
+
+ALTER TABLE product_options
+    ADD CONSTRAINT FK_product_options_color_id_colors_color_no FOREIGN KEY (color_id)
+        REFERENCES colors (color_no) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE product_options
+    ADD CONSTRAINT FK_product_options_size_id_sizes_size_no FOREIGN KEY (size_id)
+        REFERENCES sizes (size_no) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE product_options
+    ADD CONSTRAINT FK_product_id FOREIGN KEY (product_id)
+        REFERENCES products (product_no) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+INSERT INTO product_options
+(
+    product_option_no,
+    product_id,
+    color_id,
+    size_id,
+    current_quantity
+) VALUES (
+    1,
+    1,
+    1,
+    1,
+    30
+), (
+    2,
+    2,
+    3,
+    3,
+    40
+), (
+    3,
+    3,
+    3,
+    3,
+    50
+), (
+    4,
+    4,
+    3,
+    3,
+    100
+), (
+    5,
+    5,
+    3,
+    3,
+    150
+), (
+    6,
+    1,
+    8,
+    8,
+    150
+), (
+    7,
+    7,
+    3,
+    3,
+    150
+), (
+    8,
+    8,
+    3,
+    3,
+    2000
+), (
+    9,
+    9,
+    3,
+    3,
+    150
+), (
+    10,
+    10,
+    3,
+    3,
+    1500
+), (
+    11,
+    11,
+    3,
+    3,
+    1300
+), (
+    12,
+    12,
+    3,
+    3,
+    46
+), (
+    13,
+    13,
+    3,
+    3,
+    17
+), (
+    14,
+    14,
+    3,
+    3,
+    13
+), (
+    15,
+    15,
+    3,
+    3,
+    1
+), (
+    16,
+    16,
+    3,
+    3,
+    1234
+), (
+    17,
+    17,
+    3,
+    3,
+    345
+), (
+    18,
+    18,
+    3,
+    3,
+    856
+), (
+    19,
+    19,
+    3,
+    3,
+    935
+), (
+    20,
+    20,
+    3,
+    3,
+    375
+), (
+    21,
+    1,
+    1,
+    2,
+    12
+), (
+    22,
+    1,
+    1,
+    3,
+    1212
+), (
+    23,
+    1,
+    1,
+    4,
+    3000
+), (
+    24,
+    1,
+    1,
+    5,
+    300
+), (
+    25,
+    1,
+    2,
+    3,
+    0
+), (
+    26,
+    1,
+    2,
+    4,
+    150
+), (
+    27,
+    1,
+    2,
+    5,
+    99
+), (
+    28,
+    1,
+    3,
+    3,
+    20
+);
+
+-- user_shipping_details Table Create SQL
+CREATE TABLE user_shipping_details
+(
+    `user_shipping_detail_no`  INT             NOT NULL    AUTO_INCREMENT COMMENT 'pk', 
+    `user_id`                  INT             NOT NULL    COMMENT '유저_id', 
+    `address`                  VARCHAR(500)    NOT NULL    COMMENT '배송지', 
+    `additional_address`       VARCHAR(100)    NOT NULL    COMMENT '나머지 주소',
+    `zip_code`                 VARCHAR(10)     NOT NULL    COMMENT '우편번호',
+    `receiver`                 VARCHAR(50)     NOT NULL    COMMENT '수령자명', 
+    `phone_number`             VARCHAR(50)     NOT NULL    COMMENT '휴대폰번호', 
+    PRIMARY KEY (user_shipping_detail_no)
+);
+
+ALTER TABLE user_shipping_details
+    ADD CONSTRAINT FK_user_id FOREIGN KEY (user_id)
+        REFERENCES users (user_no) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+INSERT INTO user_shipping_details
+(
+    user_shipping_detail_no,
+    user_id,
+    address,
+    additional_address,
+    receiver,
+    phone_number,
+    zip_code
+) VALUES (
+    1,
+    1,
+    '서울특별시 강남구 테헤란로 32길 26',
+    '청송빌딩 브랜디',
+    '손수정수령',
+    '01012345678',
+    '42535'
+), (
+    2,
+    2,
+    '서울특별시 강남구 테헤란로 427, 위워크타워',
+    '위코드',
+    '이곤호수령',
+    '01012345678',
+    '54436'
+), (
+    3,
+    3,
+    '서울특별시 강남구 테헤란로 32길 26',
+    '청송빌딩 브랜디',
+    '이민호수령',
+    '01022223333',
+    '15279'
+), (
+    4,
+    4,
+    '서울특별시',
+    '서울 어딘가',
+    '김경배수령',
+    '01033334444',
+    '86352'
+), (
+    5,
+    5,
+    '서울특별시',
+    '서울 어딘가',
+    '배정규수령',
+    '01044445555',
+    '10001'
+);
+
+-- order_status Table Create SQL
+CREATE TABLE order_status
+(
+    `order_status_no`   INT            NOT NULL    AUTO_INCREMENT COMMENT 'pk', 
+    `name`              VARCHAR(50)    NOT NULL    COMMENT '주문상태', 
+    PRIMARY KEY (order_status_no)
+);
+
+INSERT INTO order_status
+(
+    order_status_no,
+    name
+) VALUES (
+    1,
+    '결제완료'
+), (
+    2,
+    '주문취소'
+);
+
+-- orders Table Create SQL
+CREATE TABLE orders
+(
+    `order_no`          INT         NOT NULL    AUTO_INCREMENT COMMENT 'pk', 
+    `user_id`           INT         NOT NULL    COMMENT '유저_id',
+    `created_at`        DATETIME    NOT NULL    DEFAULT CURRENT_TIMESTAMP COMMENT '생성일시', 
+    `is_deleted`        TINYINT     NOT NULL    DEFAULT FALSE COMMENT '삭제여부', 
+    PRIMARY KEY (order_no)
+);
+
+ALTER TABLE orders
+    ADD CONSTRAINT FK_orders_user_id_users_user_no FOREIGN KEY (user_id)
+        REFERENCES users (user_no) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+INSERT INTO orders
+(
+    order_no,
+    user_id,
+    created_at
+) VALUES (
+    1,
+    1,
+    '2020-08-18 15:00:00'
+), (
+    2,
+    2,
+    '2020-08-25 10:00:00'
+), (
+    3,
+    3,
+    '2020-07-25 10:00:00'
+), (
+    4,
+    4,
+    '2020-05-25 12:30:00'
+), (
+    5,
+    5,
+    '2020-05-20 11:20:00'
+);
+
+-- sub_categories Table Create SQL
+CREATE TABLE sub_categories
+(
+    `sub_category_no`   INT            NOT NULL    AUTO_INCREMENT COMMENT 'pk', 
+    `main_category_id`  INT            NOT NULL    COMMENT '1차카테고리_id', 
+    `name`              VARCHAR(50)    NOT NULL    COMMENT '카테고리명', 
+    PRIMARY KEY (sub_category_no)
+);
+
+ALTER TABLE sub_categories COMMENT '2차 카테고리';
+
+ALTER TABLE sub_categories
+    ADD CONSTRAINT FK_main_category_id FOREIGN KEY (main_category_id)
+        REFERENCES main_categories (main_category_no) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+INSERT INTO sub_categories
+(
+    sub_category_no,
+    name,
+    main_category_id
+) VALUES (
+    1,
+    '자켓',
+    1
+), (
+    2,
+    '가디건',
+    1
+), (
+    3,
+    '코트',
+    1
+), ( 
+    4,
+    '점퍼',
+    1
+), (
+    5,
+    '패딩',
+    1
+), (
+    6,
+    '무스탕/퍼',
+    1
+), (
+    7,
+    '기타',
+    1
+), (
+    8,
+    '티셔츠',
+    2
+), (
+    9,
+    '셔츠/블라우스',
+    2
+), (
+    10,
+    '니트',
+    2
+), (
+    11,
+    '후드/맨투맨',
+    2
+), ( 
+    12,
+    '베스트',
+    2
+), (
+    13,
+    '청바지',
+    3
+), (
+    14,
+    '슬랙스',
+    3
+), (
+    15, 
+    '면바지',
+    3
+), ( 
+    16, 
+    '반바지',
+    3
+), (
+    17, 
+    '트레이닝/조거',
+    3
+), (
+    18, 
+    '레깅스',
+    3
+), (
+    19, 
+    '미니',
+    4
+), (
+    20, 
+    '미디',
+    4
+), (
+    21, 
+    '롱',
+    4
+), (
+    22, 
+    '투피스',
+    4
+), (
+    23, 
+    '점프수트',
+    4
+), ( 
+    24,
+    '미니',
+    5
+), (
+    25, 
+    '미디',
+    5
+), (
+    26, 
+    '롱',
+    5
+), (
+    27, 
+    '플랫/로퍼',
+    6
+), ( 
+    28, 
+    '샌들/슬리퍼',
+    6
+), (
+    29, 
+    '힐',
+    6
+), (
+    30, 
+    '스니커즈',
+    6
+), (
+    31, 
+    '부츠/워커',
+    6
+), (
+    32, 
+    '크로스백',
+    7
+), (
+    33, 
+    '토트백',
+    7
+), (
+    34, 
+    '숄더백',
+    7
+), (
+    35, 
+    '에코백',
+    7
+), ( 
+    36, 
+    '클러치',
+    7
+), (
+    37, 
+    '백팩',
+    7
+), (
+    38, 
+    '귀걸이',
+    8
+), (
+    39, 
+    '목걸이',
+    8
+), ( 
+    40, 
+    '팔찌/발찌',
+    8
+), (
+    41, 
+    '반지',
+    8
+), (
+    42, 
+    '휴대폰 acc',
+    9
+), (
+    43, 
+    '헤어 acc',
+    9
+), (
+    44, 
+    '양말/스타킹',
+    9
+), (
+    45, 
+    '지갑/파우치',
+    9
+), (
+    46, 
+    '모자',
+    9
+), (
+    47, 
+    '벨트',
+    9
+), ( 
+    48, 
+    '시계',
+    9
+), (
+    49, 
+    '스카프',
+    9
+), (
+    50, 
+    '머플러',
+    9
+), (
+    51, 
+    '아이웨어',
+    9
+), ( 
+    52, 
+    '기타',
+    9
+), (
+    53, 
+    '언더웨어',
+    10
+), (
+    54,
+    '홈웨어',
+    10
+), (
+    55, 
+    '스윔웨어',
+    10
+), (
+    56, 
+    '비치웨어',
+    10
+), (
+    57,
+    '기타',
+    10
+), (
+    58, 
+    '아우터',
+    11
+), (
+    59, 
+    '상의',
+    11
+), ( 
+    60,
+    '바지',
+    11
+), (
+    61, 
+    '원피스',
+    11
+), (
+    62, 
+    '스커트',
+    11
+);
+
+-- orders_details Table Create SQL
+CREATE TABLE orders_details
+(
+    `order_detail_no`   INT           NOT NULL    AUTO_INCREMENT COMMENT 'pk', 
+    `order_id`          INT           NOT NULL    COMMENT '주문_id', 
+    `user_shipping_id`  INT           NOT NULL    COMMENT '배송지_id', 
+    `order_status_id`   INT           NOT NULL    COMMENT '주문상태_id', 
+    `total_price`       DECIMAL(10,2) NOT NULL    COMMENT '구매할 상품 전체 가격',
+    `start_time`        DATETIME      NOT NULL    DEFAULT CURRENT_TIMESTAMP COMMENT '선분이력관리용(생성)', 
+    `close_time`        DATETIME      NOT NULL    DEFAULT '9999-12-31 23:59:59'COMMENT '선분이력관리용(삭제)', 
+    `delivery_request`  VARCHAR(500)      NULL    COMMENT '배송시 요청사항', 
+    PRIMARY KEY (order_detail_no)
+);
+
+ALTER TABLE orders_details
+    ADD CONSTRAINT FK_user_shipping_id FOREIGN KEY (user_shipping_id)
+        REFERENCES user_shipping_details (user_shipping_detail_no) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE orders_details
+    ADD CONSTRAINT FK_order_id FOREIGN KEY (order_id)
+        REFERENCES orders (order_no) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE orders_details
+    ADD CONSTRAINT FK_order_status_id FOREIGN KEY (order_status_id)
+        REFERENCES order_status (order_status_no) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+INSERT INTO orders_details
+(
+    order_detail_no,
+    order_id,
+    user_shipping_id,
+    order_status_id,
+    total_price,
+    start_time,
+    delivery_request
+) VALUES (
+    1,
+    1,
+    1,
+    1,
+    20000,
+    '2020-08-18 15:00:00',
+    NULL
+), (
+    2,
+    2,
+    2,
+    1,
+    8890,
+    '2020-08-25 10:00:00',
+    '부재 시 전화주세요'
+), (
+    3,
+    3,
+    3,
+    1,
+    28770,
+    '2020-07-25 10:00:00',
+    '부재 시 경비실에 맡겨주세요'
+), (
+    4,
+    4,
+    4,
+    1,
+    8820,
+    '2020-05-25 12:30:00',
+    NULL
+), (
+    5,
+    5,
+    5,
+    1,
+    13230,
+    '2020-05-20 11:20:00',
+    '부재 시 문앞에 놔주세요'
+);
+
+-- images Table Create SQL
+CREATE TABLE images
+(
+    `image_no`      INT             NOT NULL    AUTO_INCREMENT COMMENT 'pk', 
+    `image_large`   VARCHAR(500)    NOT NULL    COMMENT 'Large_이미지_url', 
+    `image_medium`  VARCHAR(500)    NOT NULL    COMMENT 'Medium_이미지_url', 
+    `image_small`   VARCHAR(500)    NOT NULL    COMMENT 'Small_이미지_url', 
+    `is_deleted`    TINYINT         NOT NULL    COMMENT '삭제여부', 
+    PRIMARY KEY (image_no)
+);
+
+INSERT INTO images
+(
+    image_no,
+    image_large,
+    image_medium,
+    image_small
+) VALUES (
+    1,
+    "http://image.brandi.me/cproduct/2020/07/06/17993567_1594029654_image2_M.jpg",
+    "http://image.brandi.me/cproduct/2020/07/06/17993567_1594029654_image2_M.jpg",
+    "http://image.brandi.me/cproduct/2020/07/06/17993567_1594029654_image2_M.jpg"
+), (
+    2,
+    "http://image.brandi.me/cproduct/2020/08/20/16814508_1597899641_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/08/20/16814508_1597899641_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/08/20/16814508_1597899641_image1_M.jpg"
+), (
+    3,
+    "http://image.brandi.me/cproduct/2020/05/31/16896246_1590931916_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/05/31/16896246_1590931916_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/05/31/16896246_1590931916_image1_M.jpg"
+), (
+    4,
+    "http://image.brandi.me/cproduct/2020/05/29/16841528_1590732351_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/05/29/16841528_1590732351_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/05/29/16841528_1590732351_image1_M.jpg"
+), (
+    5,
+    "http://image.brandi.me/cproduct/2020/06/28/17786204_1593354326_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/06/28/17786204_1593354326_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/06/28/17786204_1593354326_image1_M.jpg"
+), (
+    6,
+    "http://image.brandi.me/cproduct/2020/06/21/17426352_1592713625_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/06/21/17426352_1592713625_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/06/21/17426352_1592713625_image1_M.jpg"
+), (
+    7,
+    "http://image.brandi.me/cproduct/2020/05/18/16379275_1589813844_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/05/18/16379275_1589813844_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/05/18/16379275_1589813844_image1_M.jpg"
+), (
+    8,
+    "http://image.brandi.me/cproduct/2020/08/16/18960858_1597566426_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/08/16/18960858_1597566426_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/08/16/18960858_1597566426_image1_M.jpg"
+), (
+    9,
+    "http://image.brandi.me/cproduct/2020/05/19/16448262_1589891341_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/05/19/16448262_1589891341_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/05/19/16448262_1589891341_image1_M.jpg"
+), (
+    10,
+    "http://image.brandi.me/cproduct/2020/06/08/17184315_1591610586_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/06/08/17184315_1591610586_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/06/08/17184315_1591610586_image1_M.jpg"
+), (
+    11,
+    "http://image.brandi.me/cproduct/2020/06/26/17741364_1593101362_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/06/26/17741364_1593101362_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/06/26/17741364_1593101362_image1_M.jpg"
+), (
+    12,
+    "http://image.brandi.me/cproduct/2019/08/01/9907221_1564645496_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2019/08/01/9907221_1564645496_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2019/08/01/9907221_1564645496_image1_M.jpg"
+), (
+    13,
+    "http://image.brandi.me/cproduct/2020/08/10/18846870_1597024374_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/08/10/18846870_1597024374_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/08/10/18846870_1597024374_image1_M.jpg"
+), (
+    14,
+    "http://image.brandi.me/cproduct/2020/03/05/5583139_1583400501_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/03/05/5583139_1583400501_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/03/05/5583139_1583400501_image1_M.jpg"
+), (
+    15,
+    "http://image.brandi.me/cproduct/2019/08/19/10059176_1566214986_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2019/08/19/10059176_1566214986_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2019/08/19/10059176_1566214986_image1_M.jpg"
+), (
+    16,
+    "http://image.brandi.me/cproduct/2020/04/28/15899675_1588044782_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/04/28/15899675_1588044782_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/04/28/15899675_1588044782_image1_M.jpg"
+), (
+    17,
+    "http://image.brandi.me/cproduct/2020/08/15/18895387_1597493091_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/08/15/18895387_1597493091_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/08/15/18895387_1597493091_image1_M.jpg"
+), (
+    18,
+    "http://image.brandi.me/cproduct/2020/04/09/15346962_1586364000_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/04/09/15346962_1586364000_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/04/09/15346962_1586364000_image1_M.jpg"
+), (
+    19,
+    "http://image.brandi.me/cproduct/2020/07/10/15153293_1594373068_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/07/10/15153293_1594373068_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/07/10/15153293_1594373068_image1_M.jpg"
+), (
+    20,
+    "http://image.brandi.me/cproduct/2020/06/12/17326713_1591894323_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/06/12/17326713_1591894323_image1_M.jpg",
+    "http://image.brandi.me/cproduct/2020/06/12/17326713_1591894323_image1_M.jpg"
+), (
+    21,
+    "https://image.brandi.me/cproduct/2020/07/06/17993567_1594029654_image1_L.jpg",
+    "https://image.brandi.me/cproduct/2020/07/06/17993567_1594029654_image1_L.jpg",
+    "https://image.brandi.me/cproduct/2020/07/06/17993567_1594029654_image1_L.jpg"
+), (
+    22,
+    "https://image.brandi.me/cproduct/2020/07/06/17993567_1594029656_image5_L.jpg",
+    "https://image.brandi.me/cproduct/2020/07/06/17993567_1594029656_image5_L.jpg",
+    "https://image.brandi.me/cproduct/2020/07/06/17993567_1594029656_image5_L.jpg"
+);
+
+-- product_details Table Create SQL
+CREATE TABLE product_details
+(
+    `product_detail_no`    INT              NOT NULL    AUTO_INCREMENT COMMENT 'pk', 
+    `product_id`           INT              NOT NULL    COMMENT '상품_id', 
+    `is_activated`         TINYINT          NOT NULL    COMMENT '판매여부', 
+    `is_displayed`         TINYINT          NOT NULL    COMMENT '진열여부', 
+    `main_category_id`     INT              NOT NULL    COMMENT '1차카테고리', 
+    `sub_category_id`      INT              NOT NULL    COMMENT '2차카테고리', 
+    `name`                 VARCHAR(100)     NOT NULL    COMMENT '상품명', 
+    `simple_description`   VARCHAR(500)     NULL        COMMENT '한줄 상품 설명', 
+    `detail_information`   LONGTEXT         NOT NULL    COMMENT '상품상세정보', 
+    `price`                DECIMAL(10,2)    NOT NULL    COMMENT '판매가', 
+    `discount_rate`        INT              NULL        COMMENT '할인률', 
+    `discount_start_date`  DATETIME         NULL        COMMENT '할인시작일시', 
+    `discount_end_date`    DATETIME         NULL        COMMENT '할인종료일시', 
+    `min_sales_quantity`   INT              NOT NULL    COMMENT '최소판매수량', 
+    `max_sales_quantity`   INT              NOT NULL    COMMENT '최대판매수량', 
+    `start_time`           DATETIME         NOT NULL    DEFAULT CURRENT_TIMESTAMP COMMENT '선분이력관리용(생성)', 
+    `close_time`           DATETIME         NOT NULL    DEFAULT '9999-12-31 23:59:59' COMMENT '선분이력관리용(삭제)', 
+    PRIMARY KEY (product_detail_no)
+);
+
+ALTER TABLE product_details
+    ADD CONSTRAINT FK_product_details_product_id_products_product_no FOREIGN KEY (product_id)
+        REFERENCES products (product_no) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE product_details
+    ADD CONSTRAINT FK_product_details_main_category_id FOREIGN KEY (main_category_id)
+        REFERENCES main_categories (main_category_no) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE product_details
+    ADD CONSTRAINT FK_sub_category_id FOREIGN KEY (sub_category_id)
+        REFERENCES sub_categories (sub_category_no) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+INSERT INTO product_details
+(
+    product_detail_no,
+    product_id,
+    is_activated,
+    is_displayed,
+    main_category_id,
+    sub_category_id,
+    name,
+    detail_information,
+    price,
+    min_sales_quantity,
+    max_sales_quantity,
+    discount_rate,
+    discount_start_date,
+    discount_end_date,
+    start_time,
+    close_time
+) VALUES (
+    1,
+    1,
+    1,
+    1,
+    2,
+    8,
+    '(요즘대세/여유핏) 카라 반크롭 반팔티(4color)_버튼나인 - 버튼나인',
+    '1번 상품 설명',
+    10000,
+    1,
+    20,
+    10,
+    '2020-04-20 12:00:00',
+    '2020-05-20 12:00:00',
+    '2020-04-20 12:00:00',
+    '2020-08-19 15:00:00'
+), (
+    2,
+    2,
+    1,
+    1,
+    2,
+    8,
+    '햇빛차단! 여름에도 여리핏 크롭 티셔츠(4color)_버튼나인 - 버튼나인',
+    '2번 상품 설명',
+    11110,
+    1,
+    20,
+    20,
+    NULL,
+    NULL,
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    3,
+    3,
+    1,
+    1,
+    2,
+    8,
+    '(6col/린넨) 썸머 린넨 루즈 니트 티셔츠_반하리마켓 - 반하리마켓',
+    '3번 상품 설명',
+    13700,
+    1,
+    20,
+    30,
+    '2020-04-20 15:00:00',
+    '2021-04-20 15:00:00',
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    4,
+    4,
+    1,
+    1,
+    2,
+    8,
+    '(여유핏) 데일리로딱! 반크롭 반팔티(8color)_버튼나인 - 버튼나인',
+    '4번 상품 설명',
+    8820,
+    1,
+    20,
+    NULL,
+    NULL,
+    NULL,
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    5,
+    5,
+    1,
+    1,
+    2,
+    9,
+    '박시핏 여리여리 여름셔츠 시스루 남방_블리즈 - 블리즈',
+    '5번 상품 설명',
+    13230,
+    1,
+    20,
+    NULL,
+    NULL,
+    NULL,
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    6,
+    6,
+    1,
+    1,
+    2,
+    9,
+    '린넨 슈 스퀘어 반팔 블라우스 (4 color)_로그인 - 로그인',
+    '6번 상품 설명',
+    14700,
+    1,
+    20,
+    10,
+    NULL,
+    NULL,
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    7,
+    7,
+    0,
+    1,
+    2,
+    9,
+    '르메 여름 파스텔 카라 베이직 카라 루즈핏 반팔 셔츠_프렌치오브 - 프렌치오브',
+    '7번 상품 설명',
+    13230,
+    1,
+    20,
+    20,
+    '2020-08-20 13:00:00',
+    '2020-09-04 15:00:00',
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    8,
+    8,
+    1,
+    1,
+    2,
+    9,
+    '강추 리본블라우스 가을블라우스 4col_무드글램 - 무드글램',
+    '8번 상품 설명',
+    16100,
+    1,
+    20,
+    30,
+    '2020-09-04 00:00:00',
+    '2020-10-04 00:00:00',
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    9,
+    9,
+    1,
+    1,
+    2,
+    10,
+    '(활용도굿!!) 루즈핏 레이어드 여리핏 시스루 니트 / 시스루티셔츠 / 여름니트 [6color]_오프닝무드 - 오프닝무드',
+    '9번 상품 설명',
+    9800,
+    1,
+    20,
+    NULL,
+    NULL,
+    NULL,
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    10,
+    10,
+    1,
+    1,
+    2,
+    10,
+    '브이골지티_모던제이 - 모던제이',
+    '10번 상품 설명',
+    14700,
+    1,
+    20,
+    10,
+    '2020-10-05 13:00:00',
+    '2020-10-05 14:00:00',
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    11,
+    11,
+    1,
+    0,
+    2,
+    10,
+    '(6col)민자 보트넥 썸머 여리 긴팔 니트 티셔츠_반하리마켓 - 반하리마켓',
+    '11번 상품 설명',
+    13960,
+    1,
+    20,
+    20,
+    '2020-09-05 15:00:00',
+    '2020-10-05 15:00:00',
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    12,
+    12,
+    1,
+    1,
+    2,
+    10,
+    '[여리여리핏♥V넥NT]버츠 부클 브이니트 - 헤이레이디',
+    '12번 상품 설명',
+    14900,
+    1,
+    20,
+    30,
+    NULL,
+    NULL,
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    13,
+    13,
+    1,
+    1,
+    2,
+    11,
+    '조슈아 코튼 맨투맨 - 어반로지',
+    '13번 상품 설명',
+    26500,
+    1,
+    20,
+    NULL,
+    NULL,
+    NULL,
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    14,
+    14,
+    0,
+    0,
+    2,
+    11,
+    '양기모 오버 패치 맨투맨 (5color)_모어데이 - 모어데이',
+    '14번 상품 설명',
+    18900,
+    1,
+    20,
+    10,
+    '2020-04-20 12:00:00',
+    '2020-09-05 12:00:00',
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    15,
+    15,
+    1,
+    1,
+    2,
+    11,
+    '(무료배송)풀 박시핏 워싱 피그먼트 맨투맨 - 링거인무드',
+    '15번 상품 설명',
+    34200,
+    1,
+    20,
+    20,
+    NULL,
+    NULL,
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    16,
+    16,
+    1,
+    1,
+    2,
+    11,
+    '★최저가★ 윈드 아노락세트 / 후드+반바지세트 4color_밀리 - 밀리',
+    '16번 상품 설명',
+    29520,
+    1,
+    20,
+    30,
+    '2020-09-01 00:00:00',
+    '2020-09-10 00;00:00',
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    17,
+    17,
+    1,
+    1,
+    2,
+    12,
+    '[인기]유니크골지니트조끼(4color) - 꼬맹',
+    '17번 상품 설명',
+    12900,
+    1,
+    20,
+    NULL,
+    NULL,
+    NULL,
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    18,
+    18,
+    1,
+    1,
+    2,
+    12,
+    '브이넥 니트 조끼 베스트 2color - 핀더패브릭',
+    '18번 상품 설명',
+    25730,
+    1,
+    20,
+    10,
+    NULL,
+    NULL,
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    19,
+    19,
+    1,
+    1,
+    2,
+    12,
+    '♥판매율1위♥클라우드 니트 베스트 (4color) - 스퀘어101',
+    '19번 상품 설명',
+    12780,
+    1,
+    20,
+    20,
+    NULL,
+    NULL,
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    20,
+    20,
+    1,
+    1,
+    2,
+    12,
+    '플레어 나시 블라우스 (4color)_더모닌 - 더모닌',
+    '20번 상품 설명',
+    14700,
+    1,
+    20,
+    NULL,
+    NULL,
+    NULL,
+    '2020-04-20 12:00:00',
+    DEFAULT
+), (
+    21,
+    1,
+    1,
+    1,
+    2,
+    8,
+    '선분이력테스트 (요즘대세/여유핏) 카라 반크롭 반팔티(4color)_버튼나인 - 버튼나인',
+    '1번 상품 설명 선분이력테스트',
+    11250,
+    1,
+    20,
+    30,
+    '2020-08-19 16:00:00',
+    '2020-09-15 16:00:00',
+    '2020-08-19 15:00:00',
+    DEFAULT
+);
+
+-- product_images Table Create SQL
+CREATE TABLE product_images
+(
+    `product_image_no`  INT         NOT NULL    AUTO_INCREMENT COMMENT 'pk', 
+    `product_id`        INT         NOT NULL    COMMENT '상품상세_id', 
+    `image_id`          INT         NOT NULL    COMMENT '이미지_id', 
+    `is_main`           TINYINT     NOT NULL    DEFAULT FALSE COMMENT '대표이미지여부', 
+    `start_time`        DATETIME    NOT NULL    DEFAULT CURRENT_TIMESTAMP COMMENT '선분이력관리(생성)', 
+    `close_time`        DATETIME    NOT NULL    DEFAULT '9999-12-31 23:59:59' COMMENT '선분이력관리(삭제)', 
+    PRIMARY KEY (product_image_no)
+);
+
+ALTER TABLE product_images COMMENT '상품이미지';
+
+ALTER TABLE product_images
+    ADD CONSTRAINT FK_product_images_product_id FOREIGN KEY (product_id)
+        REFERENCES products (product_no) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE product_images
+    ADD CONSTRAINT FK_image_id FOREIGN KEY (image_id)
+        REFERENCES images (image_no) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+INSERT INTO product_images
+(
+    product_image_no,
+    product_id,
+    image_id,
+    is_main,
+    start_time,
+    close_time
+) VALUES (
+    1,
+    1,
+    1,
+    1,
+    '2020-03-20 13:00:00',
+    CURRENT_TIMESTAMP
+), (
+    2,
+    2,
+    2,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    3,
+    3,
+    3,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    4,
+    4,
+    4,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    5,
+    5,
+    5,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    6,
+    6,
+    6,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    7,
+    7,
+    7,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    8,
+    8,
+    8,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    9,
+    9,
+    9,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    10,
+    10,
+    10,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    11,
+    11,
+    11,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    12,
+    12,
+    12,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    13,
+    13,
+    13,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    14,
+    14,
+    14,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    15,
+    15,
+    15,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    16,
+    16,
+    16,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    17,
+    17,
+    17,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    18,
+    18,
+    18,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    19,
+    19,
+    19,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    20,
+    20,
+    20,
+    1,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    21,
+    1,
+    21,
+    0,
+    '2020-03-20 13:00:00',
+    DEFAULT
+), (
+    22,
+    1,
+    22,
+    1,
+    CURRENT_TIMESTAMP,
+    DEFAULT
+);
+
+-- order_product Table Create SQL
+CREATE TABLE order_product
+(
+    `order_product_no`   INT    NOT NULL    AUTO_INCREMENT COMMENT 'pk', 
+    `order_detail_id`    INT    NOT NULL    COMMENT '주문상세_id', 
+    `product_option_id`  INT    NOT NULL    COMMENT '상품상세_id', 
+    `quantity`           INT    NOT NULL    COMMENT '주문수량', 
+    PRIMARY KEY (order_product_no)
+);
+
+ALTER TABLE order_product
+    ADD CONSTRAINT FK_order_product_order_detail_id FOREIGN KEY (order_detail_id)
+        REFERENCES orders_details (order_detail_no) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+ALTER TABLE order_product
+    ADD CONSTRAINT FK_order_product_product_option_id FOREIGN KEY (product_option_id)
+        REFERENCES product_options (product_option_no) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+INSERT INTO order_product
+(
+    order_product_no,
+    order_detail_id,
+    product_option_id,
+    quantity
+) VALUES (
+    1,
+    1,
+    1,
+    2
+), (
+    2,
+    2,
+    2,
+    1
+), (
+    3,
+    3,
+    3,
+    3
+), (
+    4,
+    4,
+    4,
+    1
+), (
+    5,
+    5,
+    5,
+    1
+);
+
+-- quantities Table Create SQL
+CREATE TABLE quantities
+(
+    `quantity_no`        INT         NOT NULL    AUTO_INCREMENT COMMENT 'pk', 
+    `product_option_id`  INT         NOT NULL    COMMENT '상품_옵션_id', 
+    `quantity`           INT         NOT NULL    COMMENT '재고', 
+    `start_time`         DATETIME    NOT NULL    DEFAULT CURRENT_TIMESTAMP COMMENT '선분이력관리용(생성)', 
+    `close_time`         DATETIME    NOT NULL    DEFAULT '9999-12-31 23:59:59' COMMENT '선분이력관리용(삭제)', 
+    PRIMARY KEY (quantity_no)
+);
+
+ALTER TABLE quantities
+    ADD CONSTRAINT FK_product_option_id FOREIGN KEY (product_option_id)
+        REFERENCES product_options (product_option_no) ON DELETE RESTRICT ON UPDATE RESTRICT;
+
+INSERT INTO quantities
+(
+    quantity_no,
+    product_option_id,
+    quantity
+) VALUES (
+    1,
+    1,
+    30
+), (
+    2,
+    2,
+    40
+), (
+    3,
+    3,
+    50
+), (
+    4,
+    4,
+    100
+), (
+    5,
+    5,
+    150
+), (
+    6,
+    6,
+    150
+), (
+    7,
+    7,
+    150
+), (
+    8,
+    8,
+    2000
+), (
+    9,
+    9,
+    150
+), (
+    10,
+    10,
+    1500
+), (
+    11,
+    11,
+    1300
+), (
+    12,
+    12,
+    46
+), (
+    13,
+    13,
+    17
+), (
+    14,
+    14,
+    13
+), (
+    15,
+    15,
+    1
+), (
+    16,
+    16,
+    1234
+), (
+    17,
+    17,
+    345
+), (
+    18,
+    18,
+    856
+), (
+    19,
+    19,
+    935
+), (
+    20,
+    20,
+    375
+), (
+    21,
+    21,
+    12
+), (
+    22,
+    22,
+    1212
+), (
+    23,
+    23,
+    3000
+), (
+    24,
+    24,
+    300
+), (
+    25,
+    25,
+    0
+), (
+    26,
+    26,
+    150
+), (
+    27,
+    27,
+    99
+), (
+    28,
+    28,
+    20
+);

--- a/backend/service/order_service.py
+++ b/backend/service/order_service.py
@@ -179,7 +179,7 @@ class OrderService:
         # 셀러 상품의 정보와 주문자의 정보, 주문자의 배송지 정보까지 한번에 리턴해 줍니다.
         return {**seller_product_info, **orderer_info}
 
-    def create_order_completed(self, order_info, user_no, db_connection):
+    def create_order_completed(self, order_info, db_connection):
 
         """
 
@@ -201,42 +201,105 @@ class OrderService:
 
         """
 
-        # orders_details테이블과 user_shipping_details테이블에 필요한 user_no의 정보를 order_info에 넣어줍니다.
-        order_info['user_no'] = user_no
+        # 유저의 id를 넘겨주고, orders 테이블에 insert하는 메소드를 실행 후, 해당 order_no의 id(pk)를 가져옵니다.
+        order_info['order_no'] = self.order_dao.insert_orders(order_info, db_connection)
 
-        # 해당 유저의 배송지 정보가 없었으면, 새로 받아온 후, 그 배송지 정보를 넣어주고,
-        # 만약 유저의 배송지 정보가 있었는데, 새로운 정보가 들어왔다면 그 정보로 UPDATE를 해줍니다.
-        self.order_dao.update_user_shipping_details_info(order_info, db_connection)
-
-
-        # 유저의 id를 넘겨주고, orders 테이블에 insert후, 해당 order_no의 id(pk)를 가져옵니다.
-        order_info['order_no'] = self.order_dao.insert_orders(user_no, db_connection)
-
-        # orders_details에서 생성된 테이블의 id(pk)를 order_info에 넣어줍니다.
-        order_info['order_detail_no']  = self.order_dao.insert_orders_details(order_info, db_connection)
+        # orders_details를 insert하는 메소드를 실행 후, 생성된 테이블의 id(pk)를 order_info에 넣어줍니다.
+        order_info['order_detail_no'] = self.order_dao.insert_orders_details(order_info, db_connection)
 
         # 서브쿼리를 줄이기 위해 메소드를 실행하여 product_option_no을 가져와 order_info에 넣어줍니다.
         product_option_no = self.order_dao.get_product_option_no(order_info, db_connection)
 
-        # 위에서 반환된 product_option_no은 딕셔너리이므로, order_info와 병합해 줍니다.
+        # 위에서 반환된 product_option_no 타입은 딕셔너리이므로, order_info와 병합해 줍니다.
         order_info = {**order_info, **product_option_no}
 
-        # order_product에서 생성된 테이블의 id(pk)를 order_info에 넣어줍니다.
+        # order_product를 insert하는 메소드를 실행 후, 생성된 테이블의 id(pk)를 order_info에 넣어줍니다.
         order_info['order_product_no'] = self.order_dao.insert_order_product(order_info, db_connection)
 
-        # 현재 제품의 재고의 수량을 가져오는 메소드 실행하여 id(pk)를 반환해 줍니다.
-        current_quantity_info = self.order_dao.get_current_quantity(order_info, db_connection)
+        # 주문 정보에서 받아온 상품의 개수를 현재 재고에서 빼주는 메소드 입니다.
+        self.order_dao.update_current_quantity(order_info, db_connection)
 
-        # 현재 제품의 새로운 재고를 생성하는 메소드 실행하여 id(pk)를 반홥해 줍니다.
+        # 원래 선분이력의 row id를 가져오는 메소드입니다.
+        origin_quantity_info = self.order_dao.get_origin_quantity_no(order_info, db_connection)
+
+        # 현재 옵션에 대한 재고의 선분이력을 관리해주는 quantities테이블을 생성하는 메소드 실행하여 id(pk)를 반홥해 줍니다.
         new_quantity_no = self.order_dao.insert_quantities(order_info, db_connection)
 
-        # 현재 제품의 새로운 재고가 생성된 테이블의 선분이력 생성시간을 가져옵니다.
+        # 선분이력을 관리하는 최신 재고에 대한 생성이력을 가져오는 메소드를 실행하여 start_time이라는 변수에 넣어줍니다.
         start_time = self.order_dao.get_quantity_start_time(new_quantity_no, db_connection)
 
-        # 원래 재고의 선분이력 종료시간을 update해주기 위해 새로운 테이블의 생성시간은 딕셔너리에 넣어줍니다.
-        current_quantity_info['close_time'] = start_time
-
-        # 원래 재고의 선분이력 종료시간에 새롭게 생성된 재고의 생성성시간을 넣어줍니다.
-        updated_quantity = self.order_dao.update_quantities(current_quantity_info, db_connection)
+        # quantities테이블에 선분이력 관리를 위해 새로 만들어준 선분에 해당하는 row의 정보 객체를 만들어줍니다.
+        # 원래 재고의 선분이력 종료시간을 update해주기 위해 새로운 테이블의 생성시간을 가져옵니다.
+        update_quantity_info = {
+            "origin_quantity_no" : origin_quantity_info['quantity_no'], # 원래 있었던 선분의 no
+            "start_time"         : start_time                           # 새로 생긴 선분의 start_time입니다.
+        }
+        # 선분이력을 관리하는 quantities 테이블의 종료시간에 새롭게 생성된 재고의 생성성시간을 넣어주는 메소드를 실행합니다.
+        self.order_dao.update_quantities(update_quantity_info, db_connection)
 
         return 1
+
+    def modify_user_shipping_details(self, order_info, db_connection):
+
+        """
+
+        상품 결제 시, 해당 유저의 배송지 정보가 없었다면, 받아온 배송지 정보를 Insert해주고,
+        배송지 정보가 있었다면, 받아온 배송지 정보로 Update해줍니다.
+
+        Args:
+            order_info    : 유저의 id와 배송지 관련 정보가 들어있는 객체입니다.
+            db_connection : 연결된 db 객체
+
+        Returns:
+
+        Authors:
+            minho.lee0716@gmail.com(이민호)
+
+        History:
+            2020-09-06 (minho.lee0716@gmail.com) : 초기 생성
+            2020-09-09 (minho.lee0716@gmail.com) : 수정
+                user_shipping_details 테이블과 주문관련 테이블을 따로 작업하도록 메소드를 분리하였습니다.
+
+        """
+
+        # 해당 유저의 배송지 정보를 찾는 메소드를 실행하고, 먄악 배송지 정보가 존재 할 경우,
+        if self.order_dao.select_user_shipping_details_info(order_info, db_connection):
+
+            # 받아온 정보를 유저의 배송지 정보에 Update 해줍니다.
+            self.order_dao.update_user_shipping_details_info(order_info, db_connection)
+
+        # 해당 유저의 배송지 정보가 존재하지 않을 경우,
+        else:
+
+            # 받아온 정보를 유저의 배송지 정보에 Insert 해줍니다.
+            self.order_dao.insert_user_shipping_details_info(order_info, db_connection)
+
+        return 1
+
+    def get_current_quantity(self, order_info, db_connection):
+
+        """
+
+        상품을 구매하기 전, 구매하려는 상품의 개수와 현재 상품의 재고를 비교해주는 메소드 입니다.
+
+        Args:
+            order_info    : 유저의 id와 배송지 관련 정보가 들어있는 객체입니다.
+            db_connection : 연결된 db 객체
+
+        Returns:
+
+        Authors:
+            minho.lee0716@gmail.com(이민호)
+
+        History:
+            2020-09-09 (minho.lee0716@gmail.com) : 초기 생성
+
+        """
+
+        # 해당 옵션의 상품 재고를 가져오기 위해 먼저 해당 상품의 id를 가져오는 메소드를 실행해 줍니다.
+        product_option_no = self.order_dao.get_product_option_no(order_info, db_connection)
+
+        # 해당 옵션의 상품 재고를 가져오기 위해 해당 상품 옵션의 id값을 인자로 넘겨주고 현재 재고를 받아옵니다.
+        current_quantity = self.order_dao.get_current_quantity(product_option_no, db_connection)
+
+        return current_quantity


### PR DESCRIPTION
- 결제완료 api에서 유저의 배송지 정보 관련 테이블과 주문 관련 테이블을
  실핼해주는 메소드 분리.

- 배송지 정보 관련 테이블에서 select, insert, update 쿼리를 실행해주는
  메소드 분리.

- 서비스와 다오부분의 함수들 분리.
- 현재 재고를 먼저 확인후 구매 수량보다 적으면 구매 안됨.

[ 서비스 > 상품 상세정보 ]
- 상품의 컬러 선택시, 사이즈에 대한 수량이 1개 이상인 것만 return

[ 스키마 ]
- product_oprions 테이블에 quantity 컬럼 추가.
- product_options이라는 테이블의 quantity컬럼을 current_quantity로 변경